### PR TITLE
Add: Listen to hashes and store in Listened table

### DIFF
--- a/android/app/src/main/java/com/example/dp3t_usp/BLEScannerHandler.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/BLEScannerHandler.java
@@ -27,6 +27,8 @@ public class BLEScannerHandler {
     private ScanFilter filter;
     private ScanSettings scanSettings;
 
+    private String preventOwnHash;
+
     private Context context;
 
     private ListenedHashesHelper dbListenedHelper;
@@ -53,6 +55,10 @@ public class BLEScannerHandler {
         this.scanSettings = new ScanSettings.Builder()
                 .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
                 .build();
+    }
+
+    public void setPreventOwnHash(String preventOwnHash){
+        this.preventOwnHash = preventOwnHash;
     }
 
     private void setFilters(ParcelUuid pUuid){
@@ -87,7 +93,9 @@ public class BLEScannerHandler {
                                     .getServiceUuids()
                                     .get(0)), Charset.forName("UTF-8")));
 
-            if (!isAlreadyInDb(builder.toString())){ writeHashToDB(builder.toString()); }
+            if (!isAlreadyInDb(builder.toString()) && builder.toString() != preventOwnHash){
+                writeHashToDB(builder.toString());
+            }
 
             debugDB();
         }

--- a/android/app/src/main/java/com/example/dp3t_usp/BLEService.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/BLEService.java
@@ -62,6 +62,7 @@ public class BLEService extends Service {
                 currentHash = currentHash + 1;
                 String hashedString = String.valueOf(currentHash);
                 advertiser.configData(hashedString, pUuid);
+                scanner.setPreventOwnHash(hashedString);
                 Log.e("Hash change", "Changed to " + hashedString);
                 handler.postDelayed(runnable, TIME_BETWEEN_HASH_CHANGES);
             }

--- a/android/app/src/main/java/com/example/dp3t_usp/BLEService.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/BLEService.java
@@ -75,6 +75,8 @@ public class BLEService extends Service {
     @Override
     public void onDestroy() {
         mNM.cancel(NOTIFICATION);
+        advertiser.stopAdvertising();
+        scanner.stopScanning();
         handler.removeCallbacksAndMessages(runnable);
         handler.removeCallbacks(runnable);
         Toast.makeText(this, "O DP3T não está mais capturando", Toast.LENGTH_SHORT)
@@ -110,7 +112,7 @@ public class BLEService extends Service {
     private void initializeBLE(){
         this.pUuid = new ParcelUuid(UUID.fromString(getString(R.string.ble_uuid_dp3t)));
         this.advertiser = new BLEAdvertiserHandler(this.pUuid,"0");
-        this.scanner = new BLEScannerHandler(this.pUuid);
+        this.scanner = new BLEScannerHandler(this.pUuid, this);
     }
 
 }

--- a/android/app/src/main/java/com/example/dp3t_usp/ListenedHashesContract.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/ListenedHashesContract.java
@@ -12,4 +12,6 @@ public final class ListenedHashesContract {
         public static final String COLUMN_LISTENED_HASH = "Hash";
         public static final String COLUMN_DATE = "Date";
     }
+
+    public static final String SQL_GET_ENTRY = "SELECT * FROM TABLE " + ListenedHashEntry.TABLE_NAME;
 }

--- a/android/app/src/main/java/com/example/dp3t_usp/ListenedHashesContract.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/ListenedHashesContract.java
@@ -1,0 +1,15 @@
+package com.example.dp3t_usp;
+
+import android.provider.BaseColumns;
+
+// Um contract é uma classe que define as constantes de uma tabela.
+public final class ListenedHashesContract {
+    private ListenedHashesContract(){}
+
+    // Define o conteúdo da tabela
+    public static class ListenedHashEntry implements BaseColumns{
+        public static final String TABLE_NAME = "Listened_Hashes";
+        public static final String COLUMN_LISTENED_HASH = "Hash";
+        public static final String COLUMN_DATE = "Date";
+    }
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/ListenedHashesHelper.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/ListenedHashesHelper.java
@@ -1,0 +1,37 @@
+package com.example.dp3t_usp;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+
+// Um helper é uma classe que gerencia um banco de dados. Ele cria, atualiza e destrói tabelas.
+public class ListenedHashesHelper extends SQLiteOpenHelper {
+    public static final int DATABASE_VERSION = 1;
+    public static final String DATABASE_NAME = "ListenedHashes.db";
+
+    private static final String SQL_CREATE_ENTRIES = "CREATE TABLE "
+            + ListenedHashesContract.ListenedHashEntry.TABLE_NAME + " ("
+            + ListenedHashesContract.ListenedHashEntry._ID + " INTEGER PRIMARY KEY,"
+            + ListenedHashesContract.ListenedHashEntry.COLUMN_LISTENED_HASH + " TEXT,"
+            + ListenedHashesContract.ListenedHashEntry.COLUMN_DATE + " TEXT)";
+
+    private static final String SQL_DELETE_ENTRIES = "DROP TABLE IF EXISTS " + ListenedHashesContract.ListenedHashEntry.TABLE_NAME;
+
+    public ListenedHashesHelper(Context context){
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    public void onCreate(SQLiteDatabase db){
+        db.execSQL(SQL_CREATE_ENTRIES);
+    }
+
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion){
+        db.execSQL(SQL_DELETE_ENTRIES);
+        onCreate(db);
+    }
+
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion){
+        onUpgrade(db, oldVersion, newVersion);
+    }
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/MainActivity.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/MainActivity.java
@@ -36,7 +36,7 @@ public class MainActivity extends AppCompatActivity {
 
     // Background service
     private Intent backgroundServiceIntent;
-    
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
Adiciona a feature de ouvir hashes do ambiente e armazenar um lido do UUID pertinente em uma tabela de hashes ouvidos junto com a data do momento.

- Cria o ListenedHashesContract.java, classe que define o formato da tabela de hashes ouvidos;
- Cria o ListenedHashesHelper.java, classe que gerencia a criação e destruição da tabela no dispositivo do usuário;
- Adapta o scanner para inserir o hash ouvido na tabela de hashes ouvidos;
- Faz a MainActivity passar o seu contexto como argumento para o scanner;