### PR TITLE
Add: Infected and last expo db definition

### DIFF
--- a/android/app/src/main/java/com/example/dp3t_usp/CheckExposureTask.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/CheckExposureTask.java
@@ -1,0 +1,53 @@
+package com.example.dp3t_usp;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.HashMap;
+
+public class CheckExposureTask {
+
+    // Mudar o endpoint de onde a gente vai retirar os hashes
+    private final static String endpointCheck = "localhost:1234";
+    private Context context;
+
+    public CheckExposureTask(Context context) {
+        this.context = context;
+    }
+
+    // Função para realizar a operação de checagem
+    public static void checkExposure(){
+
+    }
+
+    // Função para pegar hashes infectados do endpoint
+    private void getHashes() {
+        RequestPackage requestPackage = new RequestPackage();
+        requestPackage.setMethod(RequestPackage.methods.GET.toString());
+        requestPackage.setUrl(endpointCheck);
+
+        String lastCheckDate = getLastCheckDate();
+
+        HashMap<String, String> lastCheckParam = new HashMap<String,String>();
+
+        lastCheckParam.put("last_check", lastCheckDate);
+
+        requestPackage.setParams(lastCheckParam);
+
+        RequestMaker requestMaker = new RequestMaker();
+        requestMaker.execute(requestPackage);
+        // TODO: Até aqui foi executada a requisição. Agora é questão de parsear o retorno
+        //  e tornar acessível.
+    }
+
+    // Acessa o valor guardado da última checagem e retorna esta data.
+    private String getLastCheckDate(){
+        LastExposureCheckHelper lastExposureCheckHelper = new LastExposureCheckHelper(context);
+        SQLiteDatabase sqLiteDatabase = lastExposureCheckHelper.getReadableDatabase();
+        Cursor cursor = sqLiteDatabase.rawQuery(LastExposureCheckContract.SQL_GET_ENTRY,null);
+        cursor.moveToFirst();
+        int lastCheckCollumnIndex = cursor.getColumnIndex(LastExposureCheckContract.LastExposureCheckEntry.LAST_CHECK);
+        return cursor.getString(lastCheckCollumnIndex);
+    }
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/InfectedHashesContract.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/InfectedHashesContract.java
@@ -1,0 +1,14 @@
+package com.example.dp3t_usp;
+
+import android.provider.BaseColumns;
+
+public class InfectedHashesContract {
+    private InfectedHashesContract(){}
+
+    // Define o conteúdo da tabela
+    public static class InfectedHashEntry implements BaseColumns {
+        public static final String TABLE_NAME = "Infected_Hashes";
+        public static final String COLUMN_INFECTED_HASH = "Hash";
+        public static final String COLUMN_DATE = "Check Date";
+    }
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/InfectedHashesHelper.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/InfectedHashesHelper.java
@@ -1,0 +1,35 @@
+package com.example.dp3t_usp;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class InfectedHashesHelper extends SQLiteOpenHelper {
+    public static final int DATABASE_VERSION = 1;
+    public static final String DATABASE_NAME = "InfectedHashes.db";
+
+    private static final String SQL_CREATE_ENTRIES = "CREATE TABLE "
+            + InfectedHashesContract.InfectedHashEntry.TABLE_NAME + " ("
+            + InfectedHashesContract.InfectedHashEntry._ID + " INTEGER PRIMARY KEY,"
+            + InfectedHashesContract.InfectedHashEntry.COLUMN_INFECTED_HASH + " TEXT,"
+            + InfectedHashesContract.InfectedHashEntry.COLUMN_DATE + " TEXT)";
+
+    private static final String SQL_DELETE_ENTRIES = "DROP TABLE IF EXISTS " + InfectedHashesContract.InfectedHashEntry.TABLE_NAME;
+
+    public InfectedHashesHelper(Context context){
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    public void onCreate(SQLiteDatabase db){
+        db.execSQL(SQL_CREATE_ENTRIES);
+    }
+
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion){
+        db.execSQL(SQL_DELETE_ENTRIES);
+        onCreate(db);
+    }
+
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion){
+        onUpgrade(db, oldVersion, newVersion);
+    }
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/LastExposureCheckContract.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/LastExposureCheckContract.java
@@ -1,0 +1,15 @@
+package com.example.dp3t_usp;
+
+import android.provider.BaseColumns;
+
+public class LastExposureCheckContract {
+    private LastExposureCheckContract(){}
+
+    // Define o conteúdo da tabela
+    public static class LastExposureCheckEntry implements BaseColumns {
+        public static final String TABLE_NAME = "Last_Exposure_Check";
+        public static final String LAST_CHECK = "Last_Check";
+    }
+
+    public static final String SQL_GET_ENTRY = "SELECT * FROM TABLE " + LastExposureCheckContract.LastExposureCheckEntry.TABLE_NAME;
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/LastExposureCheckHelper.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/LastExposureCheckHelper.java
@@ -1,0 +1,36 @@
+package com.example.dp3t_usp;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class LastExposureCheckHelper extends SQLiteOpenHelper {
+    public static final int DATABASE_VERSION = 1;
+    public static final String DATABASE_NAME = "LastExposureCheck.db";
+
+    private static final String SQL_CREATE_ENTRIES = "CREATE TABLE "
+            + LastExposureCheckContract.LastExposureCheckEntry.TABLE_NAME + " ("
+            + LastExposureCheckContract.LastExposureCheckEntry._ID + " INTEGER PRIMARY KEY,"
+            + LastExposureCheckContract.LastExposureCheckEntry.LAST_CHECK + " TEXT)";
+
+    private static final String SQL_DELETE_ENTRIES = "DROP TABLE IF EXISTS " + LastExposureCheckContract.LastExposureCheckEntry.TABLE_NAME;
+
+    public LastExposureCheckHelper(Context context){
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    public void onCreate(SQLiteDatabase db){
+        db.execSQL(SQL_CREATE_ENTRIES);
+    }
+
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion){
+        db.execSQL(SQL_DELETE_ENTRIES);
+        onCreate(db);
+    }
+
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion){
+        onUpgrade(db, oldVersion, newVersion);
+    }
+
+
+}

--- a/android/app/src/main/java/com/example/dp3t_usp/RequestPackage.java
+++ b/android/app/src/main/java/com/example/dp3t_usp/RequestPackage.java
@@ -40,6 +40,8 @@ public class RequestPackage {
         return params;
     }
 
+    public void setParams(Map<String, String> params){this.params = params;}
+
     public String getPostData(){
         return postData;
     }


### PR DESCRIPTION
- Cria as definições de db para uma tabela de last expo (que guarda a data da última data que fizera uma requisição);

- Cria as definições de db para uma tabela de hashes infectados;

- Criou-se a classe responsável por fazer a tarefa de:

1. Requisitar os hashes do endpoint
2. Remover todos os hashes da tabela local de hashes infectados que datarem mais de 14 dias;
3. Adicionar todos os hashes obtidos na tabela;
4. Atualizar a data da requisição na tabela de last expo

Apenas a 1 foi feita.